### PR TITLE
PROCO ontology suffix bug

### DIFF
--- a/src/ontology/instance test data/crystallization-01.ttl
+++ b/src/ontology/instance test data/crystallization-01.ttl
@@ -25,14 +25,14 @@
 
 # crystallization experiment
 <urn:uuid:74142d9d-cdfa-4b9e-9309-c4ccba173c1d>
-	a	<http://semanticscience.org/resource/SIO_000994> opc:OPC_0000052 ; # experiment, crystallization  
+	a	<http://semanticscience.org/resource/SIO_000994> opc:PROCO_0000052 ; # experiment, crystallization  
 		af-x:AFX_0002802 <urn:uuid:f5aa5d9f-6943-48f3-b910-48524965c25e> ;
 		af-x:AFX_00000696 <urn:uuid:3e153662-f169-429d-9a42-1880f94c03cd> , <urn:uuid:529bce3c-75db-41e4-ad9a-fb633f5669d9>  ; # has material input
 		af-x:AFX_00000546 <urn:uuid:93f3daa6-98b8-469f-be97-ad2aabbf056f> , <urn:uuid:67d83de5-a8b0-446b-b5d6-b62ff9758cfe> . # has material output
 
 # notebook
-<urn:uuid:f5aa5d9f-6943-48f3-b910-48524965c25e> a 	opc:OPC_0000116; # laboratory notebook		
-		af-x:AFX_0002716 [ a opc:OPC_0000281;
+<urn:uuid:f5aa5d9f-6943-48f3-b910-48524965c25e> a 	opc:PROCO_0000116; # laboratory notebook		
+		af-x:AFX_0002716 [ a opc:PROCO_0000281;
 							af-x:AFX_0000690 "1001-9999"^^xsd:string ]  .
 		
 		
@@ -68,7 +68,7 @@
 						
 # filter cake						
 <urn:uuid:93f3daa6-98b8-469f-be97-ad2aabbf056f>
-	a	af-m:AFM_0001060; # , opc:OPC_0000289 ;  # portion of compound, product stream
+	a	af-m:AFM_0001060; # , opc:PROCO_0000289 ;  # portion of compound, product stream
 		af-x:AFX_0002802 [	a	af-r:AFR_0000922 ;                             # af-r:description
 						af-x:AFX_0000690  "filter cake" ] ;           # af-x:has value
 	ro:RO_0000087	[	a	af-rl:AFRL_0000360 ; # product role
@@ -92,7 +92,7 @@
 	a	af-m:AFM_0001060, opc:OPC_0000288 ;  # portion of compound, waste stream
 		af-x:AFX_0002802 [	a	af-r:AFR_0000922 ;                             # af-r:description
 						af-x:AFX_0000690  "mother liquors" ] ;           # af-x:has value
-	ro:RO_0000087	[	a	opc:OPC_0000072 ; # mother liquor role
+	ro:RO_0000087	[	a	opc:PROCO_0000072 ; # mother liquor role
 						bfo:BFO_0000054	<urn:uuid:74142d9d-cdfa-4b9e-9309-c4ccba173c1d> ] .
 
 						


### PR DESCRIPTION
`OPC_` is used as suffix of `PROCO` ontology terms. However the correct suffix pattern is `PROCO_`